### PR TITLE
Add missing placeholder version for 'jax-rs-providers.gson.version'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 	  	<javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
 		<javaee-web-api.version>7.0</javaee-web-api.version>
 		<jaxrs.version>2.0</jaxrs.version>
+		<jax-rs-providers.gson.version>2.3</jax-rs-providers.gson.version>
 		<jersey.version>2.22.2</jersey.version>
 		<junit-version>4.12</junit-version>
 		<karaf.version>4.0.9</karaf.version>


### PR DESCRIPTION
Version is not populated correctly for ${jax-rs-providers.gson.version} in the features.xml since the value was not defined. This PR defines the value so the version can be replaced.